### PR TITLE
fix bug timeout deprecated

### DIFF
--- a/lib/net/snmp/listener.rb
+++ b/lib/net/snmp/listener.rb
@@ -54,7 +54,7 @@ module Net::SNMP
         begin
           return if @killed
           # TODO: Not exactly the most efficient solution...
-          timeout(@interval) do
+          Timeout.timeout(@interval) do
             @packet = @socket.recvfrom(@max_packet_size)
           end
           return if @killed


### PR DESCRIPTION
Replace timeout by Timeout.timeout for remove warning: Object#timeout is deprecated